### PR TITLE
Add recursive flag to mkdir to avoid error messges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+blahaj/
+*.swp

--- a/getBlahajStats.php
+++ b/getBlahajStats.php
@@ -4,10 +4,10 @@ $grosserhai = "https://www.ikea.com/de/de/iows/catalog/availability/30373588/";
 
 
 if(!is_dir("blahaj/klein/" . date("Y-m-d") . "/")) {
-    mkdir("blahaj/klein/" . date("Y-m-d") . "/");
+    mkdir("blahaj/klein/" . date("Y-m-d") . "/", 0777, true);
 }
 if(!is_dir("blahaj/gross/" . date("Y-m-d") . "/")) {
-    mkdir("blahaj/gross/" . date("Y-m-d") . "/");
+    mkdir("blahaj/gross/" . date("Y-m-d") . "/", 0777, true);
 }
 
 exec("wget --tries=90 --user-agent=\"Mozilla/5.0 (Windows NT 6.1; rv:68.0) Gecko/20100101 Firefox/68.0\" -O blahaj/klein/" . date("Y-m-d") . "/" . date("H") . ".xml " . $kleinerhai);


### PR DESCRIPTION
When runnning `php getBlahajStats.php` a PHp Warning is ommited:

 - PHP Warning:  mkdir(): No such file or directory in /home/user/Documents/jkd/getBlahajStats.php on line 7
 - PHP Warning:  mkdir(): No such file or directory in /home/user/Documents/jkd/getBlahajStats.php on line 10

This issue fixes this by passing true for the recursive flag of the mkdir command in the respective lines